### PR TITLE
Prevent race condition

### DIFF
--- a/src/main/scala/play/dev/filewatch/PollingFileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/PollingFileWatchService.scala
@@ -43,6 +43,11 @@ object SourceModificationWatch {
 
   @tailrec def watch(sourcesFinder: PathFinder, pollDelayMillis: Int, state: WatchState)(terminationCondition: => Boolean): (Boolean, WatchState) =
     {
+      if (pollDelayMillis < 1000) {
+        throw new IllegalArgumentException(
+          "pollDelayMillis must be at least 1000 since many filesystems only support second-level granularity for last-modification time")
+      }
+
       import state._
 
       val sourceFilesPath: Set[String] = sourcesFinder().map(_.toJava.getCanonicalPath).toSet


### PR DESCRIPTION
If you poll, change a file, poll again within a second then the polling watch service will never return since we can't detect changes at less than a second granularity. Make sure that we wait more than a second before polling so that we can detect changes