### PR TITLE
Scala 2.12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ target
 .classpath
 .project
 .settings/
+.idea/
 bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+
+language: scala
+scala:
+- 2.12.1
+- 2.11.8
+- 2.10.6
+jdk:
+- oraclejdk8
+script:
+- sbt ++$TRAVIS_SCALA_VERSION test
+cache:
+  directories:
+  - "$HOME/.ivy2/cache"
+before_cache:
+- rm -rf $HOME/.ivy2/cache/com.lightbend.play/*
+- rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.lightbend.play/*
+- find $HOME/.ivy2/cache -name "ivydata-*.properties" -print0 | xargs -n10 -0 rm
+notifications:
+  slack:
+    secure: JPXUQyHjF3FKac8EdQimLZA5B4iGGtMsslK9w+tjgcNbupbuqErAmLdlebJU7lOVaPYbk9DrKjaqx82248hVca++t5uhEuj1Qgijl3Fn3VdTyv94D+wQ0p/5iiNjTOF1TS5R8NnY6WHaXfMD/ibGnlZKHHjgGX3RyszHmg8YWVxD8+Y/0uE+q9LddPeeGWGEmWgfwHS8fI+5c3/f7cwv7r2wEkHpXOorZbDLlyjD7/b22GBw+8/rsIEEnURNOI7A58IDJHRG4JAkv+Y/vX4i7mPSWdD4/YD6shAy0Jgxk8tNV4WtU8Mq9cV3/Kd8P+hWAaSd6aAhsaj+kNq9C2ZrTDVDe02tcZ34j0g0oaPZQDXTLATHdo0qX9sf+k5EWm25swkhn4CotcqBZ8frDwfO07j9n3lj5lxLauaRzurwoNYaY6nuDjPzFwi1vA6VqYHUnR0z0k+rh7EPbmgZjqtLH8gdwbYqE96NTd1O0A6kngMJ1T6FhHhmNbK6uepAp94q96s41OoyBXMc9pFx8V9dksMzGvvm0n1Or+B7F38OKjX9CMsCh/tuv/wC1sTc6dKh7Eg+odfwEUM1DuGS3JU5qMRkXqvj6aOeoCp+tvU9ZGWA/iELiQKlX4tZ4kY5Onj4VgWjfaKsx3FpnLt3kBXFL2UUF/+scumV31USgTKSEnA=

--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,18 @@ lazy val `play-file-watch` = project
       // sbt-io is not quite ready to be used as a stand alone library in something that needs to support both sbt 0.13
       // and maven. These reasons include sbt-io 0.13.x isn't published to maven central, and sbt-io 1.0.x may not
       // support Scala 2.10.
-      "com.github.pathikrit" %% "better-files" % "2.17.1",
+      betterFiles(scalaVersion.value),
       "org.specs2" %% "specs2-core" % "3.8.6" % Test
     )
   )
+
+def betterFiles(scalaVersion: String): ModuleID = {
+  val version = scalaVersion.split('.')(1) match {
+    case "10" => "2.17.0"
+    case "11" | "12" => "2.17.1"
+  }
+  "com.github.pathikrit" %% "better-files" % version
+}
 
 playBuildRepoName in ThisBuild := "play-file-watch"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,15 +4,15 @@ lazy val `play-file-watch` = project
   .settings(scalariformSettings: _*)
   .settings(interplayOverrideSettings: _*)
   .settings(
-    crossScalaVersions := Seq("2.10.6", "2.11.8"),
+    crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1"),
     libraryDependencies ++= Seq(
       "com.lightbend.play" % "jnotify" % "0.94-play-2",
       // Using this rather than sbt-io because it also needs to run on maven, and due to various circumstantial reasons,
       // sbt-io is not quite ready to be used as a stand alone library in something that needs to support both sbt 0.13
       // and maven. These reasons include sbt-io 0.13.x isn't published to maven central, and sbt-io 1.0.x may not
       // support Scala 2.10.
-      "com.github.pathikrit" %% "better-files" % "2.14.0",
-      "org.specs2" %% "specs2-core" % "3.6.6" % Test
+      "com.github.pathikrit" %% "better-files" % "2.17.1",
+      "org.specs2" %% "specs2-core" % "3.8.6" % Test
     )
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 
-addSbtPlugin("com.typesafe.play" % "interplay" % "1.1.2")
+addSbtPlugin("com.typesafe.play" % "interplay" % "1.3.4")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.7")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 

--- a/src/main/scala/play/dev/filewatch/FileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/FileWatchService.scala
@@ -28,7 +28,9 @@ trait FileWatchService {
    * @return A watcher
    */
   def watch(filesToWatch: JList[File], onChange: Callable[Void]): FileWatcher = {
-    watch(JavaConversions.asScalaBuffer(filesToWatch), () => { onChange.call })
+    val buffer: Seq[java.io.File] = JavaConversions.asScalaBuffer(filesToWatch)
+    val function: () => Unit = () => { onChange.call }
+    watch(buffer, function)
   }
 
 }

--- a/src/main/scala/play/dev/filewatch/FileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/FileWatchService.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.util.concurrent.Callable
 import java.util.{ List => JList, Locale }
 
-import scala.collection.JavaConversions
+import scala.collection.JavaConverters._
 import scala.util.{ Properties, Try }
 
 /**
@@ -28,7 +28,7 @@ trait FileWatchService {
    * @return A watcher
    */
   def watch(filesToWatch: JList[File], onChange: Callable[Void]): FileWatcher = {
-    val buffer: Seq[java.io.File] = JavaConversions.asScalaBuffer(filesToWatch)
+    val buffer: Seq[java.io.File] = filesToWatch.asScala
     val function: () => Unit = () => { onChange.call }
     watch(buffer, function)
   }

--- a/src/main/scala/play/dev/filewatch/JavaFileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/JavaFileWatchService.scala
@@ -47,9 +47,9 @@ class JavaFileWatchService(logger: LoggerProxy) extends FileWatchService {
 
             val events = watchKey.pollEvents()
 
-            import scala.collection.JavaConversions._
+            import scala.collection.JavaConverters._
             // If a directory has been created, we must watch it and its sub directories
-            events.foreach { event =>
+            events.asScala.foreach { event =>
 
               if (event.kind == ENTRY_CREATE) {
                 val file = watchKey.watchable.asInstanceOf[Path].resolve(event.context.asInstanceOf[Path]).toFile


### PR DESCRIPTION
Fixes #5. This adds scala 2.12 support and uses better-files instead of sbt-io. We need a slightly different version of better-files for scala 2.10 but it's compatible.

Also closes #6.