### PR TITLE
Added unit tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ lazy val `play-file-watch` = project
       // support Scala 2.10.
       betterFiles(scalaVersion.value),
       "org.specs2" %% "specs2-core" % "3.8.6" % Test
-    )
+    ),
+    parallelExecution in Test := false
   )
 
 def betterFiles(scalaVersion: String): ModuleID = {

--- a/src/main/scala/play/dev/filewatch/FileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/FileWatchService.scala
@@ -79,6 +79,8 @@ object FileWatchService {
     }
 
     def watch(filesToWatch: Seq[File], onChange: () => Unit) = delegate.watch(filesToWatch, onChange)
+
+    override def toString = delegate.toString
   }
 
   def jnotify(targetDirectory: File): FileWatchService = optional(JNotifyFileWatchService(targetDirectory))

--- a/src/test/scala/play/dev/filewatch/FileWatchServiceSpec.scala
+++ b/src/test/scala/play/dev/filewatch/FileWatchServiceSpec.scala
@@ -1,0 +1,103 @@
+package play.dev.filewatch
+
+import better.files._
+
+import org.specs2.mutable.Specification
+import scala.concurrent.duration._
+
+class JavaFileWatchServiceSpec extends FileWatchServiceSpec {
+  override def watchService = FileWatchService.jdk7(FileWatchServiceSpecLoggerProxy)
+}
+
+class PollingFileWatchServiceSpec extends FileWatchServiceSpec {
+  override def watchService = FileWatchService.polling(200)
+}
+
+class JNotifyFileWatchServiceSpec extends FileWatchServiceSpec {
+  private val jnotifyDir = File("./target/jnotify").createIfNotExists(asDirectory = true)
+  override def watchService = FileWatchService.jnotify(jnotifyDir.toJava)
+}
+
+object FileWatchServiceSpecLoggerProxy extends LoggerProxy {
+  override def verbose(message: => String) = ()
+  override def debug(message: => String) = ()
+  override def info(message: => String) = ()
+  override def warn(message: => String) = ()
+  override def error(message: => String) = ()
+  override def trace(t: => Throwable) = ()
+  override def success(message: => String) = ()
+}
+
+abstract class FileWatchServiceSpec extends Specification {
+
+  sequential
+
+  def watchService: FileWatchService
+
+  private def withTempDir[T](block: File => T): T = {
+    val baseDir = File.newTemporaryDirectory("file-watch-service")
+    try {
+      block(baseDir)
+    } finally {
+      baseDir.delete()
+    }
+  }
+
+  @volatile var changed = false
+
+  private def assertChanged() = {
+    val deadline = 5.seconds.fromNow
+    while (!changed) {
+      if (deadline.isOverdue()) {
+        failure("Changed did not become true within 5 seconds")
+      }
+      Thread.sleep(200)
+    }
+    ok
+  }
+
+  private def reset() = {
+    Thread.sleep(50)
+    changed = false
+  }
+
+  private def watchFiles[T](files: File*)(block: => T): T = {
+    changed = false
+    val watcher = watchService.watch(files.map(_.toJava), () => changed = true)
+    try {
+      block
+    } finally {
+      watcher.stop()
+    }
+  }
+
+  "The file watch service" should {
+
+    "detect new files" in withTempDir { dir =>
+      watchFiles(dir) {
+        (dir / "test").write("new file")
+        assertChanged()
+      }
+    }
+
+    "detect changes on files" in withTempDir { dir =>
+      val testFile = dir / "test"
+      testFile.write("new file")
+      watchFiles(dir) {
+        testFile.write("changed")
+        assertChanged()
+      }
+    }
+
+    "detect changes on files in new subdirectories" in withTempDir { dir =>
+      watchFiles(dir) {
+        val subDir = dir.createChild("subdir", asDirectory = true)
+        assertChanged()
+        reset()
+        (subDir / "test").write("new file")
+        assertChanged()
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
I wanted to fix a bug (specfically handling when a root watched directory was deleted), but then I found out that it's not really practical to fix it (you can't watch a non existent directory, we'd have to poll until the directory was created which is not really practical). But anyway, in the process of doing this I created these unit tests which I thought would be helpful.

There's also a bug in better files where it assumes that entry file in a zip file always has a parent directory. I'm not sure that this is true, and in fact the JNotify unit tests would not work without working around this bug. What I don't understand is what is so different about the JNotify tests, as far as I can see this should never have worked. It could be related to the upgrade of better files - Play 2.6.0 is still on play-file-watch 1.0.0, maybe that didn't have the same bug? Looking at the source code as far as I can see it did, so I really don't know. Anyway, it's fixed.