### PR TITLE
[WIP]: Replace copied code from sbt with sbt-io

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,4 +12,9 @@ install:
 build_script:
   - sbt compile
 test_script:
-  - sbt test
+  # -Djna.nosys=true is required to avoid the following error:
+  # There is an incompatible JNA native library installed on this system
+  #
+  # There is an issue in sbt-io about it:
+  # https://github.com/sbt/io/issues/110
+  - sbt -Djna.nosys=true test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,8 @@ os: Windows Server 2012
 environment:
   JAVA_OPTS: -Dfile.encoding=UTF8
   SBT_OPTS: -Dfile.encoding=UTF8
+  matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
   - cmd: choco install sbt -ia "INSTALLDIR=""C:\sbt"""
   - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val `play-file-watch` = project
     crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.6"),
     libraryDependencies ++= Seq(
       "io.methvin" % "directory-watcher" % "0.5.0",
+      "org.scala-sbt" %% "io" % "1.1.10",
       betterFiles(scalaBinaryVersion.value),
       specs2(scalaBinaryVersion.value) % Test,
 

--- a/src/main/scala/play/dev/filewatch/FileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/FileWatchService.scala
@@ -84,9 +84,9 @@ object FileWatchService {
       case _ => polling(pollDelayMillis)
     }
 
-    def watch(filesToWatch: Seq[File], onChange: () => Unit) = delegate.watch(filesToWatch, onChange)
+    override def watch(filesToWatch: Seq[File], onChange: () => Unit): FileWatcher = delegate.watch(filesToWatch, onChange)
 
-    override def toString = delegate.toString
+    override def toString: String = delegate.toString
   }
 
   def jnotify(targetDirectory: File): FileWatchService = optional(JNotifyFileWatchService(targetDirectory))
@@ -106,7 +106,7 @@ object FileWatchService {
  * Watch service that delegates to a try. This allows it to exist without reporting an exception unless it's used.
  */
 class OptionalFileWatchServiceDelegate(val watchService: Try[FileWatchService]) extends FileWatchService {
-  def watch(filesToWatch: Seq[File], onChange: () => Unit) = {
+  override def watch(filesToWatch: Seq[File], onChange: () => Unit): FileWatcher = {
     watchService.map(ws => ws.watch(filesToWatch, onChange)).get
   }
 }

--- a/src/main/scala/play/dev/filewatch/PlaySourceModificationWatch.scala
+++ b/src/main/scala/play/dev/filewatch/PlaySourceModificationWatch.scala
@@ -1,0 +1,35 @@
+package sbt.internal.io {
+
+  import java.io.File
+
+  import scala.concurrent.duration.FiniteDuration
+
+  object PlaySourceModificationWatch {
+
+    // This needs to be here because most of the classes used by this method are
+    // private/internal to sbt-io.
+    def emptyWatchState(files: Seq[File], initialDelay: FiniteDuration): WatchState = {
+      val sbtPollingWatchService = new sbt.io.PollingWatchService(initialDelay)
+      val sources = getParentDirs(files).map(Source(_))
+      val emptyState = WatchState.empty(sbtPollingWatchService, sources)
+      emptyState
+    }
+
+    // Internally, sbt-io handle the directories recursively.
+    // This is just a small optimization.
+    private def getParentDirs(files: Seq[File]): Seq[File] = {
+      files.map {
+        case dir if dir.isDirectory => dir
+        case file if file.isFile => file.getParentFile
+      }.distinct
+    }
+
+    def watch(
+      state: WatchState,
+      delay: FiniteDuration
+    )(terminationCondition: => Boolean): (Boolean, WatchState) = {
+      SourceModificationWatch.watch(delay, state)(terminationCondition)
+    }
+  }
+}
+

--- a/src/main/scala/play/dev/filewatch/PollingFileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/PollingFileWatchService.scala
@@ -1,91 +1,41 @@
 package play.dev.filewatch
 
 import java.io.File
+import java.util.concurrent.TimeUnit
 
-import better.files.{ File => ScalaFile, _ }
+import sbt.internal.io.PlaySourceModificationWatch
 
-import annotation.tailrec
+import scala.concurrent.duration._
 
 /**
  * A polling Play watch service. Polls in the background.
  */
-class PollingFileWatchService(val pollDelayMillis: Int) extends FileWatchService {
+class PollingFileWatchService(val pollDelay: FiniteDuration, val antiEntropy: FiniteDuration = 40.milliseconds) extends FileWatchService {
 
-  def watch(filesToWatch: Seq[File], onChange: () => Unit) = {
+  @deprecated("Use pollDelay Duration instead", "1.1.8")
+  lazy val pollDelayMillis: Int = pollDelay.toMillis.toInt
+
+  def this(pollDelayMillis: Int) = this(Duration(pollDelayMillis, TimeUnit.MILLISECONDS))
+
+  override def watch(filesToWatch: Seq[File], onChange: () => Unit): FileWatcher = {
 
     @volatile var stopped = false
 
     val thread = new Thread(new Runnable {
-      def run() = {
-        var state = WatchState.empty
+      override def run(): Unit = {
+        var state = PlaySourceModificationWatch.emptyWatchState(filesToWatch, pollDelay)
         while (!stopped) {
-          val (triggered, newState) = SourceModificationWatch.watch(
-            () => filesToWatch.iterator.flatMap(_.toScala.listRecursively),
-            pollDelayMillis, state)(stopped)
+          val (triggered, newState) = PlaySourceModificationWatch.watch(state, pollDelay)(stopped)
           if (triggered) onChange()
           state = newState
         }
       }
-    }, "play-watch-service")
+    }, "play-polling-watch-service")
     thread.setDaemon(true)
     thread.start()
 
     new FileWatcher {
-      def stop() = stopped = true
+      override def stop(): Unit = stopped = true
     }
   }
 }
-
-/**
- * Copied from sbt.
- */
-object SourceModificationWatch {
-  type PathFinder = () => Iterator[ScalaFile]
-
-  private def listFiles(sourcesFinder: PathFinder): Set[ScalaFile] = sourcesFinder().toSet
-
-  private def findLastModifiedTime(files: Set[ScalaFile]): Long = {
-    if (files.nonEmpty) files.maxBy(_.lastModifiedTime).lastModifiedTime.toEpochMilli
-    else 0L
-  }
-
-  @tailrec def watch(sourcesFinder: PathFinder, pollDelayMillis: Int, state: WatchState)(terminationCondition: => Boolean): (Boolean, WatchState) =
-    {
-      import state._
-
-      val filesToWatch = listFiles(sourcesFinder)
-
-      val sourceFilesPath: Set[String] = filesToWatch.map(_.toJava.getCanonicalPath)
-      val lastModifiedTime = findLastModifiedTime(filesToWatch)
-
-      val sourcesModified =
-        lastModifiedTime > lastCallbackCallTime ||
-          previousFiles != sourceFilesPath
-
-      val (triggered, newCallbackCallTime) =
-        if (sourcesModified)
-          (false, System.currentTimeMillis)
-        else
-          (awaitingQuietPeriod, lastCallbackCallTime)
-
-      val newState = new WatchState(newCallbackCallTime, sourceFilesPath, sourcesModified, if (triggered) count + 1 else count)
-      if (triggered)
-        (true, newState)
-      else {
-        Thread.sleep(pollDelayMillis)
-        if (terminationCondition)
-          (false, newState)
-        else
-          watch(sourcesFinder, pollDelayMillis, newState)(terminationCondition)
-      }
-    }
-}
-
-final class WatchState(val lastCallbackCallTime: Long, val previousFiles: Set[String], val awaitingQuietPeriod: Boolean, val count: Int) {
-  def previousFileCount: Int = previousFiles.size
-}
-
-object WatchState {
-  def empty = new WatchState(0L, Set.empty[String], false, 0)
-}
-


### PR DESCRIPTION
This requires sbt-io as a dependency, and most of the code referenced is private/internal to sbt. It is better to do it that way since we can then notice when sbt code changes in a way that is not compatible with what we are done for play-file-watching.

## WIP DO NOT MERGE

I submitting this so that the code can be tested in both Linux (travis) and Windows (appveyor).