### PR TITLE
Make play-file-watch compile against better-files 3.7.0 sources

### DIFF
--- a/src/main/scala/play/dev/filewatch/JNotifyFileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/JNotifyFileWatchService.scala
@@ -137,7 +137,7 @@ private object JNotifyFileWatchService {
   private def unzipTo(thisFile: ScalaFile, destination: ScalaFile)(implicit codec: Codec): destination.type = {
     import scala.collection.JavaConverters._
     for {
-      zipFile <- new ZipFile(thisFile.toJava, codec).autoClosed
+      zipFile <- new ZipFile(thisFile.toJava, codec.charSet).autoClosed
       entry <- zipFile.entries().asScala
       file = (destination / entry.getName).createIfNotExists(entry.isDirectory, createParents = true)
       if !entry.isDirectory


### PR DESCRIPTION
Looks like better-files 2.17's codecToCharSet implicit isn't present in
3.7.0, so stop relying on it to unblock the scala 2.12.x community
build.