### PR TITLE
Provide a flag to disable file hash check

### DIFF
--- a/src/main/scala/play/dev/filewatch/DefaultFileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/DefaultFileWatchService.scala
@@ -15,7 +15,7 @@ import scala.util.control.NonFatal
  * Implementation of the file watch service that uses a native implementation for Mac and otherwise uses the JDK's
  * WatchService implementation.
  */
-class DefaultFileWatchService(logger: LoggerProxy, isMac: Boolean, disableFileHashCheck: Boolean)
+class DefaultFileWatchService(logger: LoggerProxy, isMac: Boolean, disableFileHashCheck: Boolean = false)
     extends FileWatchService {
 
   def this(logger: LoggerProxy) = this(logger, false, false)

--- a/src/main/scala/play/dev/filewatch/DefaultFileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/DefaultFileWatchService.scala
@@ -15,10 +15,11 @@ import scala.util.control.NonFatal
  * Implementation of the file watch service that uses a native implementation for Mac and otherwise uses the JDK's
  * WatchService implementation.
  */
-class DefaultFileWatchService(logger: LoggerProxy, isMac: Boolean, disableFileHashCheck: Boolean = false)
+class DefaultFileWatchService(logger: LoggerProxy, isMac: Boolean, disableFileHashCheck: Boolean)
     extends FileWatchService {
 
-  def this(logger: LoggerProxy) = this(logger, false, false)
+  def this(logger: LoggerProxy) = this(logger, isMac = false, disableFileHashCheck = false)
+  def this(logger: LoggerProxy, isMac: Boolean) = this(logger, isMac, disableFileHashCheck = false)
 
   def watch(filesToWatch: Seq[File], onChange: () => Unit) = {
     val dirsToWatch = filesToWatch.filter { file =>

--- a/src/main/scala/play/dev/filewatch/DefaultFileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/DefaultFileWatchService.scala
@@ -15,9 +15,10 @@ import scala.util.control.NonFatal
  * Implementation of the file watch service that uses a native implementation for Mac and otherwise uses the JDK's
  * WatchService implementation.
  */
-class DefaultFileWatchService(logger: LoggerProxy, isMac: Boolean) extends FileWatchService {
+class DefaultFileWatchService(logger: LoggerProxy, isMac: Boolean, disableFileHashCheck: Boolean)
+    extends FileWatchService {
 
-  def this(logger: LoggerProxy) = this(logger, false)
+  def this(logger: LoggerProxy) = this(logger, false, false)
 
   def watch(filesToWatch: Seq[File], onChange: () => Unit) = {
     val dirsToWatch = filesToWatch.filter { file =>
@@ -38,6 +39,7 @@ class DefaultFileWatchService(logger: LoggerProxy, isMac: Boolean) extends FileW
         .listener(new DirectoryChangeListener {
           override def onEvent(event: DirectoryChangeEvent): Unit = onChange()
         })
+        .fileHashing(!disableFileHashCheck)
         .watchService(watchService)
         .build()
 

--- a/src/main/scala/play/dev/filewatch/FileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/FileWatchService.scala
@@ -73,7 +73,7 @@ object FileWatchService {
       targetDirectory: File,
       pollDelayMillis: Int,
       logger: LoggerProxy,
-      disableFileHashCheck: Boolean = false
+      disableFileHashCheck: Boolean
   ): FileWatchService =
     new FileWatchService {
       lazy val delegate = os match {
@@ -97,21 +97,31 @@ object FileWatchService {
       override def toString = delegate.toString
     }
 
+  def defaultWatchService(targetDirectory: File, pollDelayMillis: Int, logger: LoggerProxy): FileWatchService =
+    defaultWatchService(targetDirectory, pollDelayMillis, logger, disableFileHashCheck = false)
+
   def jnotify(targetDirectory: File): FileWatchService = optional(JNotifyFileWatchService(targetDirectory))
 
-  def jdk7(logger: LoggerProxy, disableFileHashCheck: Boolean = false): FileWatchService =
+  def jdk7(logger: LoggerProxy, disableFileHashCheck: Boolean): FileWatchService =
     default(logger, isMac = false, disableFileHashCheck)
 
-  def mac(logger: LoggerProxy, disableFileHashCheck: Boolean = false): FileWatchService =
+  def jdk7(logger: LoggerProxy): FileWatchService = jdk7(logger, disableFileHashCheck = false)
+
+  def mac(logger: LoggerProxy, disableFileHashCheck: Boolean): FileWatchService =
     default(logger, isMac = true, disableFileHashCheck)
+
+  def mac(logger: LoggerProxy): FileWatchService = mac(logger, disableFileHashCheck = false)
 
   def polling(pollDelayMillis: Int): FileWatchService = new PollingFileWatchService(pollDelayMillis)
 
   def optional(watchService: Try[FileWatchService]): FileWatchService =
     new OptionalFileWatchServiceDelegate(watchService)
 
-  def default(logger: LoggerProxy, isMac: Boolean, disableFileHashCheck: Boolean = false): FileWatchService =
+  def default(logger: LoggerProxy, isMac: Boolean, disableFileHashCheck: Boolean): FileWatchService =
     new DefaultFileWatchService(logger, isMac, disableFileHashCheck)
+
+  def default(logger: LoggerProxy, isMac: Boolean): FileWatchService =
+    default(logger, isMac, disableFileHashCheck = true)
 }
 
 /**

--- a/src/main/scala/play/dev/filewatch/FileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/FileWatchService.scala
@@ -121,7 +121,7 @@ object FileWatchService {
     new DefaultFileWatchService(logger, isMac, disableFileHashCheck)
 
   def default(logger: LoggerProxy, isMac: Boolean): FileWatchService =
-    default(logger, isMac, disableFileHashCheck = true)
+    default(logger, isMac, disableFileHashCheck = false)
 }
 
 /**

--- a/src/main/scala/play/dev/filewatch/FileWatchService.scala
+++ b/src/main/scala/play/dev/filewatch/FileWatchService.scala
@@ -73,7 +73,7 @@ object FileWatchService {
       targetDirectory: File,
       pollDelayMillis: Int,
       logger: LoggerProxy,
-      disableFileHashCheck: Boolean
+      disableFileHashCheck: Boolean = false
   ): FileWatchService =
     new FileWatchService {
       lazy val delegate = os match {
@@ -99,10 +99,10 @@ object FileWatchService {
 
   def jnotify(targetDirectory: File): FileWatchService = optional(JNotifyFileWatchService(targetDirectory))
 
-  def jdk7(logger: LoggerProxy, disableFileHashCheck: Boolean): FileWatchService =
+  def jdk7(logger: LoggerProxy, disableFileHashCheck: Boolean = false): FileWatchService =
     default(logger, isMac = false, disableFileHashCheck)
 
-  def mac(logger: LoggerProxy, disableFileHashCheck: Boolean): FileWatchService =
+  def mac(logger: LoggerProxy, disableFileHashCheck: Boolean = false): FileWatchService =
     default(logger, isMac = true, disableFileHashCheck)
 
   def polling(pollDelayMillis: Int): FileWatchService = new PollingFileWatchService(pollDelayMillis)
@@ -110,7 +110,7 @@ object FileWatchService {
   def optional(watchService: Try[FileWatchService]): FileWatchService =
     new OptionalFileWatchServiceDelegate(watchService)
 
-  def default(logger: LoggerProxy, isMac: Boolean, disableFileHashCheck: Boolean): FileWatchService =
+  def default(logger: LoggerProxy, isMac: Boolean, disableFileHashCheck: Boolean = false): FileWatchService =
     new DefaultFileWatchService(logger, isMac, disableFileHashCheck)
 }
 

--- a/src/test/scala/play/dev/filewatch/FileWatchServiceSpec.scala
+++ b/src/test/scala/play/dev/filewatch/FileWatchServiceSpec.scala
@@ -9,14 +9,32 @@ class JavaFileWatchServiceSpec extends FileWatchServiceSpec {
   // the mac impl consistently fails because it takes more than 5s so skip this one on mac
   args(skipAll = FileWatchService.os == FileWatchService.OS.Mac)
 
-  override def watchService: FileWatchService = FileWatchService.jdk7(FileWatchServiceSpecLoggerProxy)
+  override def watchService: FileWatchService =
+    FileWatchService.jdk7(FileWatchServiceSpecLoggerProxy, disableFileHashCheck = false)
+}
+
+class JavaFileWatchServiceHashCheckDisabledSpec extends FileWatchServiceSpec {
+  // the mac impl consistently fails because it takes more than 5s so skip this one on mac
+  args(skipAll = FileWatchService.os == FileWatchService.OS.Mac)
+
+  override def watchService: FileWatchService =
+    FileWatchService.jdk7(FileWatchServiceSpecLoggerProxy, disableFileHashCheck = true)
 }
 
 class MacFileWatchServiceSpec extends FileWatchServiceSpec {
   // this only works on mac
   args(skipAll = FileWatchService.os != FileWatchService.OS.Mac)
 
-  override def watchService: FileWatchService = FileWatchService.mac(FileWatchServiceSpecLoggerProxy)
+  override def watchService: FileWatchService =
+    FileWatchService.mac(FileWatchServiceSpecLoggerProxy, disableFileHashCheck = false)
+}
+
+class MacFileWatchServiceHashCheckDisabledSpec extends FileWatchServiceSpec {
+  // this only works on mac
+  args(skipAll = FileWatchService.os != FileWatchService.OS.Mac)
+
+  override def watchService: FileWatchService =
+    FileWatchService.mac(FileWatchServiceSpecLoggerProxy, disableFileHashCheck = true)
 }
 
 class JNotifyFileWatchServiceSpec extends FileWatchServiceSpec {


### PR DESCRIPTION
https://github.com/gmethvin/directory-watcher does file hash check by default
to deduplicate change events. But that can increase the startup time on
large code base.

Fixes #110 