### PR TITLE
Update directory-watcher to 0.15.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val `play-file-watch` = project
         Nil
     ),
     libraryDependencies ++= Seq(
-      "io.methvin"            % "directory-watcher" % "0.14.0",
+      "io.methvin"            % "directory-watcher" % "0.15.0",
       "com.github.pathikrit" %% "better-files" % pickVersion(
         scalaBinaryVersion.value,
         default = "3.8.0",


### PR DESCRIPTION
Improved macOS Big Sur / M1 compatibility.