### PR TITLE
Drop Scala 2.10 + 2.11

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v2
     with:
       java: 11, 8
-      scala: 2.10.7, 2.11.12, 2.12.16, 2.13.8, 3.2.0
+      scala: 2.12.16, 2.13.8, 3.2.0
       cmd: sbt ++$MATRIX_SCALA test
 
   finish:

--- a/build.sbt
+++ b/build.sbt
@@ -27,23 +27,12 @@ lazy val `play-file-watch` = project
     ),
     libraryDependencies ++= Seq(
       "io.methvin"             % "directory-watcher" % "0.16.1",
-      ("com.github.pathikrit" %% "better-files" % pickVersion(
-        scalaBinaryVersion.value,
-        default = "3.9.1",
-        forScala210 = "2.17.0"
-      )).cross(CrossVersion.for3Use2_13),
-      scalaBinaryVersion.value match {
-        case "2.10" =>
-          "org.specs2" %% "specs2-core" % "3.10.0" % Test
-        case "2.11" =>
-          "org.specs2" %% "specs2-core" % "4.10.6" % Test
-        case _ =>
-          "org.specs2" %% "specs2-core" % "4.16.1" % Test
-      }
+      ("com.github.pathikrit" %% "better-files"      % "3.9.1").cross(CrossVersion.for3Use2_13),
+      "org.specs2"            %% "specs2-core"       % "4.16.1" % Test
     ),
     Test / parallelExecution := false,
     mimaPreviousArtifacts := {
-      if (scalaBinaryVersion.value == "2.10" || scalaBinaryVersion.value == "3")
+      if (scalaBinaryVersion.value == "3")
         Set.empty
       else
         Set(
@@ -59,11 +48,6 @@ lazy val `play-file-watch` = project
       ProblemFilters.exclude[MissingClassProblem]("play.dev.filewatch.JNotifyFileWatchService$JNotifyDelegate"),
     )
   )
-
-def pickVersion(scalaBinaryVersion: String, default: String, forScala210: String): String = scalaBinaryVersion match {
-  case "2.10" => forScala210
-  case _      => default
-}
 
 addCommandAlias(
   "validateCode",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -29,6 +29,8 @@ object Common extends AutoPlugin {
     "-feature",
     "-unchecked",
     "-Xlint",
+    "-Ywarn-unused:imports",
+    "-Xlint:nullary-unit",
     "-Ywarn-dead-code"
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,12 +4,9 @@
 import sbt._
 
 object Dependencies {
-  // to allow for use in sbt 0.13
-  val Scala210 = "2.10.7"
-  val Scala211 = "2.11.12"
   val Scala212 = "2.12.16"
   val Scala213 = "2.13.8"
   val Scala3   = "3.2.0"
 
-  val ScalaVersions = Seq(Scala210, Scala211, Scala212, Scala213, Scala3)
+  val ScalaVersions = Seq(Scala212, Scala213, Scala3)
 }

--- a/src/main/scala/play/dev/filewatch/GlobalStaticVar.scala
+++ b/src/main/scala/play/dev/filewatch/GlobalStaticVar.scala
@@ -60,7 +60,7 @@ private[filewatch] object GlobalStaticVar {
         )
       }
     } catch {
-      case e: InstanceNotFoundException =>
+      case _: InstanceNotFoundException =>
         None
     }
   }
@@ -72,7 +72,7 @@ private[filewatch] object GlobalStaticVar {
     try {
       ManagementFactory.getPlatformMBeanServer.unregisterMBean(objectName(name))
     } catch {
-      case e: InstanceNotFoundException =>
+      case _: InstanceNotFoundException =>
     }
   }
 }


### PR DESCRIPTION
This was done in #70, but because of #100 / #10450 reverted in in #109 this was for 1.1.x, we are on 1.2.x now already, so it's time now to finally get rid of it.