### PR TITLE
Throw exceptions instead of being silent, just like Scala

### DIFF
--- a/src/main/java/play/dev/filewatch/PollingFileWatchService.java
+++ b/src/main/java/play/dev/filewatch/PollingFileWatchService.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /** A polling Play watch service. Polls in the background. */
@@ -29,7 +28,7 @@ public class PollingFileWatchService implements FileWatchService {
               try {
                 return Files.walk(file.toPath()).filter(path -> !path.equals(file.toPath()));
               } catch (IOException e) {
-                return Stream.empty();
+                throw new RuntimeException(e);
               }
             })
         .map(Path::toFile)

--- a/src/main/java/play/dev/filewatch/SourceModificationWatch.java
+++ b/src/main/java/play/dev/filewatch/SourceModificationWatch.java
@@ -27,7 +27,7 @@ public final class SourceModificationWatch {
     try {
       return Files.getLastModifiedTime(file.toPath()).toInstant().toEpochMilli();
     } catch (IOException e) {
-      return 0L;
+      throw new RuntimeException(e);
     }
   }
 
@@ -76,7 +76,7 @@ public final class SourceModificationWatch {
                     try {
                       return file.getCanonicalPath();
                     } catch (IOException e) {
-                      return null;
+                      throw new RuntimeException(e);
                     }
                   })
               .filter(Objects::nonNull)


### PR DESCRIPTION
This was bothering me a bit while reviewing 

- #242

because even though Scala does not require you to catch checked exceptions, it does throw them at runtime if they occur.
I don't really like being silent and just swallowing the errors and continuing like nothing happened. If people get strange behaviour because some files can't be watched or whatever it's very hard to figure out what's going on, so IMHO better to just fail with an exception. Given that the equivalent Scala code did the same, I guess this exceptions will not really occur in real life anyway.

Also, look at that better-files says about the `walk` method:
 - https://github.com/pathikrit/better-files/blob/v3.9.2/core/src/main/scala/better/files/File.scala#L743
  ```scala
      Files.walk(path, maxDepth, visitOptions: _*) // TODO: that ignores I/O errors?
  ```

So the devs were not even sure what's happening (this line was added 8+ years ago to be fair). What happens is at Runtime the `IOException` will be thrown. What they did now is:
https://github.com/pathikrit/better-files/commit/0a22873bd4ae837ee6de892dc3fee4559f7e439a#diff-1eed0c8cd6c94c548b033043e1669d94cb999fd88dc17d9bc3db3f6247fb51e2L689
move that in and GitHub issue https://github.com/pathikrit/better-files/issues/590 so they figure out what to do.
Anyway, I think throwing is better now. Actually nothing changes from previous play-file-watch versions...